### PR TITLE
Add Tree Ring Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Coordinate multiple models and tools locally.
 - [NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails) - Programmable guardrails for LLM apps from NVIDIA. Input/output filters, fact-checking, dialogue policies. Wraps any local model.
 - [Outlines](https://github.com/dottxt-ai/outlines) - Structured generation for LLMs. Force outputs to follow JSON schema, regex, or context-free grammars. Works with llama.cpp, vLLM, transformers.
 - [Instructor](https://github.com/instructor-ai/instructor) - Reliable structured outputs from any LLM via Pydantic models. Retries on validation failure. Works with local models via Ollama and LiteLLM.
+- [Tree Ring Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory) - Local agent memory lifecycle with SQLite/FTS recall, audit, and forgetting.
 
 ## Model Management
 


### PR DESCRIPTION
Adds Tree Ring Memory to the Orchestration & Agents section.

Why it fits this list:
- Runs locally as a Rust CLI/TUI with project-scoped SQLite/FTS storage.
- MIT licensed and actively maintained.
- Helps local-agent builders manage searchable, auditable, and forgettable memory.
- Uses one concise source-link row with a 10-word description.

Validation performed:
- Searched existing PRs and code for Tree Ring Memory; no existing listing found.
- Verified the Tree Ring GitHub URL returns HTTP 200.
- Verified README contains exactly one Tree Ring Memory link.
- Verified Tree Ring is MIT licensed and active as of 2026-07-07.
- Ran `git diff --check`.