### PR TITLE
Add OpenAgentRelay to local agent orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Coordinate multiple models and tools locally.
 - [NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails) - Programmable guardrails for LLM apps from NVIDIA. Input/output filters, fact-checking, dialogue policies. Wraps any local model.
 - [Outlines](https://github.com/dottxt-ai/outlines) - Structured generation for LLMs. Force outputs to follow JSON schema, regex, or context-free grammars. Works with llama.cpp, vLLM, transformers.
 - [Instructor](https://github.com/instructor-ai/instructor) - Reliable structured outputs from any LLM via Pydantic models. Retries on validation failure. Works with local models via Ollama and LiteLLM.
+- [OpenAgentRelay](https://github.com/ShakespeareLabs/open-agent-relay) - Expose restricted local agents as keyed trusted-LAN capabilities while keeping source and credentials on the publisher's machine.
 
 ## Model Management
 


### PR DESCRIPTION
## Summary

Add OpenAgentRelay to **Orchestration & Agents** with a factual description under 20 words.

## Fit

OpenAgentRelay runs on the user's own hardware and exposes a restricted local agent or automation only over a keyed trusted LAN. The publisher's source, prompts, dependencies, working directory, and credentials remain local. Its CLI supports JSON output, expected-agent validation, meaningful exit codes, and bounded conversations for composing local agent workflows.

It is open source, actively maintained, and does not require a cloud service. The current Alpha documentation explicitly advises against public-internet exposure and production write operations.

## Checklist

- [x] Runs locally on user hardware
- [x] Updated within the last six months
- [x] One line, under 20 words
- [x] No marketing language
- [x] Open-source tier
