### PR TITLE
Add light-ocr to Privacy-First Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Interact with documents without data leaving your machine.
 - [LocalGPT](https://github.com/PromtEngineer/localGPT) - Chat with documents using local models. Inspired by PrivateGPT with more model options.
 - [Danswer](https://github.com/danswer-ai/danswer) - Search and chat over internal documents. Can use local models. Self-hosted.
 - [AnythingLLM](https://github.com/Mintplex-Labs/anything-llm) - All-in-one AI desktop app with local RAG and agent support. Connects to Ollama.
+- [light-ocr](https://github.com/arcships/light-ocr) - Offline OCR library and CLI for Node.js and C++. PP-OCRv6 via ONNX Runtime; no Python runtime.
 
 ## Unified Gateways
 


### PR DESCRIPTION
## Summary

Adds light-ocr to Privacy-First Tools as an offline OCR library and CLI for Node.js and C++.

## Verification

- Confirmed it runs OCR locally through PP-OCRv6 and ONNX Runtime.
- Confirmed it has no Python runtime requirement.
- Kept the entry to one factual line, following CONTRIBUTING.md.