### PR TITLE
Add Atomic Agent to Code Assistants and Orchestration & Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Coordinate multiple models and tools locally.
 - [NeMo Guardrails](https://github.com/NVIDIA/NeMo-Guardrails) - Programmable guardrails for LLM apps from NVIDIA. Input/output filters, fact-checking, dialogue policies. Wraps any local model.
 - [Outlines](https://github.com/dottxt-ai/outlines) - Structured generation for LLMs. Force outputs to follow JSON schema, regex, or context-free grammars. Works with llama.cpp, vLLM, transformers.
 - [Instructor](https://github.com/instructor-ai/instructor) - Reliable structured outputs from any LLM via Pydantic models. Retries on validation failure. Works with local models via Ollama and LiteLLM.
+- [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) - Agent runtime with 56 built-in tools, MCP support, and a five-layer local memory system. Single-agent, not a multi-agent framework. Still in developer preview.
 
 ## Model Management
 
@@ -155,6 +156,7 @@ AI-powered coding without sending your code to the cloud.
 - [Tabby](https://github.com/TabbyML/tabby) - Self-hosted code completion and chat. Runs on your GPU. GitHub Copilot alternative.
 - [Aider](https://github.com/Aider-AI/aider) - AI pair programming in your terminal. Edit files, run tests, commit. Works with local models via Ollama/LiteLLM.
 - [llm](https://github.com/simonw/llm) - CLI tool for interacting with LLMs. Plugins for local models. From the creator of Datasette.
+- [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) - Terminal coding assistant running open-weight models on your machine via a llama.cpp fork. No API key needed. Developer preview, so expect breaking changes.
 
 ## Voice & Audio
 


### PR DESCRIPTION
Hi! I'm the CPO of Atomic Agent. Thanks for this list, the "works offline after initial setup" framing is exactly the bar we build against, and our team would be thrilled if you added us.

**Atomic Agent** ([github.com/AtomicBot-ai/atomic-agent](https://github.com/AtomicBot-ai/atomic-agent)) is a local-first CLI and TUI coding assistant. It runs open-weight models entirely on your machine through a llama.cpp fork, so no account or API key is required to install or run it. The TUI is built on React and ink. It ships 56 built-in tools (browser, filesystem, git, memory, vision), supports MCP, and has a five-layer local memory system. macOS, Linux, and Windows. MIT licensed, ~2k stars, active.

Install:

```
curl -fsSL https://atomicagent.io/install | sh
```

### Where I added it

Two entries, both appended to the end of their section since neither list is alphabetized:

- **Code Assistants** - the primary fit. It is a terminal coding assistant in the same slot as Aider and llm, with the difference that the model runs locally by default rather than through Ollama or LiteLLM as a bring-your-own backend.
- **Orchestration & Agents** - the tool loop, MCP support, and memory layer are the other half of what it does, and that is a different question than "which coding assistant should I use". Happy to drop this second entry if you would rather keep one line per tool.

### Against your rules

- Runs locally on the user's own hardware. Not cloud-only.
- Actively maintained, commits within the last week.
- One line per tool, descriptions under 20 words.
- No marketing speak, and I kept both notes practical. One flags that it is single-agent rather than a multi-agent framework, so nobody arrives expecting CrewAI. The other flags the developer preview status.

One honest caveat worth stating up front: the repo carries an official "Developer preview. APIs, commands, config, and behavior are still moving" notice, and it is about four months old. It is active and maintained by the AtomicBot-ai organization, which ships several established projects, but I mentioned the preview status in both rows rather than leaving readers to find out on their own. If that puts it too early for the list, no hard feelings, and I would rather you say so than list something that frustrates your readers.

More: [atomicagent.io](https://atomicagent.io) | [docs](https://atomicagent.io/docs) | [Discord](https://discord.gg/Us7qXtDGw) | [X](https://x.com/atomicagent_io)

Thanks for maintaining this.
